### PR TITLE
Csillagos 5-ös kártyájának színe a Mainpage-en.

### DIFF
--- a/lib/Cards/EvaluationCard.dart
+++ b/lib/Cards/EvaluationCard.dart
@@ -63,6 +63,10 @@ class EvaluationCard extends StatelessWidget {
           break;
       }
       switch (evaluation.Value) {
+        case "5*":
+          bColor = globals.color5;
+          fColor = Colors.white;
+          break;
         case "Példás":
           bColor = globals.color5;
           fColor = Colors.white;


### PR DESCRIPTION
A Mainpage oldalon nem színeződik a csillagos 5-ös szekció (normál és dark módban sem). Logikus lenne, ha a settings-ben beállított 5-ös jegynek megfelelő színt venne fel.